### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/GDScript.YAML-tmLanguage
+++ b/GDScript.YAML-tmLanguage
@@ -28,7 +28,7 @@ patterns:
   begin: '@"'
   end: (?<!\\)"
 - name: constant.numeric.integer.hexadecimal.gdscript
-  match: \b(?i:0x\h*)\b
+  match: \b(?i:0x[0-9A-Fa-f]*)\b
 - name: constant.numeric.float.gdscript
   match: \b(?i:(\d+\.\d*(e[\-\+]?\d+)?))\b
 - name: constant.numeric.float.gdscript

--- a/GDScript.tmLanguage
+++ b/GDScript.tmLanguage
@@ -82,7 +82,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(?i:0x\h*)\b</string>
+			<string>\b(?i:0x[0-9A-Fa-f]*)\b</string>
 			<key>name</key>
 			<string>constant.numeric.integer.hexadecimal.gdscript</string>
 		</dict>


### PR DESCRIPTION
Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Atom uses an Oniguruma engine, but github.com relies on a PCRE
engine.